### PR TITLE
No need for bidict

### DIFF
--- a/gymnast/pdf_constants.py
+++ b/gymnast/pdf_constants.py
@@ -4,7 +4,6 @@ Constants needed mostly for PDF character encoding
 
 import binascii
 import os
-from bidict import bidict
 
 __all__  = ['EOLS', 'WHITESPACE', 'BASE_ENCODINGS', 'GLYPH_LIST']
 DATA_DIR = os.path.dirname(os.path.abspath(__file__))+'/data/'
@@ -32,13 +31,11 @@ def decode_hex(hex_str):
                      for i in hex_str.split()]).decode('utf-16-be')
 
 def get_glyph_list():
-    """Load the Adobe Glyph list into a bidict.
+    """Load the Adobe Glyph list into a dict.
     https://partners.adobe.com/public/developer/en/opentype/glyphlist.txt"""
 
     with open(DATA_DIR + 'glyphlist.txt') as f:
         lines = [l.split(';') for l in f.read().splitlines() if l[0] != '#']
-    # Dedupe, because Adobe
-    glyph_set = {l[0] for l in lines}
-    return bidict({l[0]: decode_hex(l[1]) for l in lines if l[0] not in glyph_set})
+    return {l[0]: decode_hex(l[1]) for l in lines}
 
 GLYPH_LIST = get_glyph_list()


### PR DESCRIPTION
There are only 2 places that uses glyph list, and none of them require inverse lookup. This removes the logic for deduping altogether.
